### PR TITLE
Arreglar prints Menu

### DIFF
--- a/Conversion.ipynb
+++ b/Conversion.ipynb
@@ -89,7 +89,7 @@
     }
    ],
    "source": [
-    "    #Este metodo se encarga de calcular la parte entera del decimal ingresado para asi ser usado en el metodo decimalbinario \n",
+    "    #Este metodo se encarga de calcular la parte entera del decimal ingresado para asi ser usado en el metodo decimalbinario.\n",
     "def enteroBinario(numero):\n",
     "    \"\"\"    \n",
     "    Documentation:\n",


### PR DESCRIPTION
 Algunos prints tienen mal la información que esta asociada a los métodos a los cuales se llaman al elegir la opción.